### PR TITLE
Add dropdown language selector in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,14 +55,6 @@
     a:hover {
       text-decoration: underline;
     }
-    .lang-toggle {
-      margin-bottom: 2rem;
-    }
-    .lang-toggle button {
-      margin-right: 0.5rem;
-      padding: 0.4rem 0.8rem;
-      font-size: 0.9rem;
-    }
     nav {
       position: fixed;
       top: 0;
@@ -72,6 +64,7 @@
       color: #fff;
       padding: 1rem;
       display: flex;
+      align-items: center;
       justify-content: center;
       gap: 1rem;
       box-shadow: 0 2px 5px rgba(0,0,0,0.2);
@@ -80,6 +73,32 @@
     nav a {
       color: #fff;
       text-decoration: none;
+    }
+    .dropdown {
+      position: relative;
+      margin-left: auto;
+    }
+    .dropbtn {
+      background-color: var(--primary-color);
+      color: #fff;
+      border: none;
+      cursor: pointer;
+      font-size: 1rem;
+    }
+    .dropdown-content {
+      display: none;
+      position: absolute;
+      background-color: var(--primary-color);
+      min-width: 120px;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    }
+    .dropdown-content a {
+      color: #fff;
+      padding: 0.5rem 1rem;
+      display: block;
+    }
+    .dropdown:hover .dropdown-content {
+      display: block;
     }
     .hero img {
       width: 100%;
@@ -98,10 +117,6 @@
 </head>
 <body>
 
-  <div class="lang-toggle">
-    <button onclick="toggleLanguage('en')">English</button>
-    <button onclick="toggleLanguage('de')">Deutsch</button>
-  </div>
 
   <div data-lang="en">
     <nav>
@@ -111,6 +126,13 @@
       <a href="#sessions">Sessions</a>
       <a href="#testimonials">Testimonials</a>
       <a href="#contact">Contact</a>
+        <div class="dropdown">
+          <button class="dropbtn">🌐</button>
+          <div class="dropdown-content">
+            <a href="#" onclick="toggleLanguage('en'); return false;">🇬🇧 English</a>
+            <a href="#" onclick="toggleLanguage('de'); return false;">🇩🇪 Deutsch</a>
+          </div>
+        </div>
     </nav>
     <div class="hero"><img src="https://via.placeholder.com/1200x400" alt="Hero image"></div>
     <section id="about">
@@ -203,6 +225,13 @@
       <a href="#sessions">Sessions</a>
       <a href="#testimonials">Erfahrungsberichte</a>
       <a href="#contact">Kontakt</a>
+        <div class="dropdown">
+          <button class="dropbtn">🌐</button>
+          <div class="dropdown-content">
+            <a href="#" onclick="toggleLanguage('en'); return false;">🇬🇧 English</a>
+            <a href="#" onclick="toggleLanguage('de'); return false;">🇩🇪 Deutsch</a>
+          </div>
+        </div>
     </nav>
     <div class="hero"><img src="https://via.placeholder.com/1200x400" alt="Hero image"></div>
     <section id="about">


### PR DESCRIPTION
## Summary
- integrate language selection into the navigation bar
- implement dropdown menu with German and English flags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f400c6344832e8a53c1a1ab04fac2