### PR TITLE
Remove eval-based script

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
       margin-top: 2.5rem;
     }
   </style>
-  <script>
+<script>
     function toggleLanguage(lang) {
       document.querySelectorAll('[data-lang]').forEach(el => {
         el.style.display = el.dataset.lang === lang ? 'block' : 'none';
@@ -225,15 +225,9 @@
 
     <section id="contact" class="contact">
       <h2>📬 Contact</h2>
-      <iframe data-tally-src="https://tally.so/embed/3Nv510?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="276" frameborder="0" marginheight="0" marginwidth="0" title="Wild Tender Hearts "></iframe>
-      <script>
-        var d=document,w="https://tally.so/widgets/embed.js",v=function(){"undefined"!=typeof Tally?Tally.loadEmbeds():d.querySelectorAll("iframe[data-tally-src]:not([src])").forEach(function(e){e.src=e.dataset.tallySrc})};
-        if("undefined"!=typeof Tally) v();
-        else if(d.querySelector('script[src="'+w+'"]')==null){var s=d.createElement("script");s.src=w,s.onload=v,s.onerror=v,d.body.appendChild(s);}
-      </script>
+      <iframe src="https://tally.so/embed/3Nv510?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="276" frameborder="0" marginheight="0" marginwidth="0" title="Wild Tender Hearts "></iframe>
     </section>
   </div>
-
   <div data-lang="de" style="display:none">
     <nav>
       <a href="#about">Über mich</a>
@@ -325,12 +319,7 @@
 
         <section id="contact" class="contact">
           <h2>📬 Kontakt</h2>
-          <iframe data-tally-src="https://tally.so/embed/3Nv510?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="276" frameborder="0" marginheight="0" marginwidth="0" title="Wild Tender Hearts "></iframe>
-          <script>
-            var d=document,w="https://tally.so/widgets/embed.js",v=function(){"undefined"!=typeof Tally?Tally.loadEmbeds():d.querySelectorAll("iframe[data-tally-src]:not([src])").forEach(function(e){e.src=e.dataset.tallySrc})};
-            if("undefined"!=typeof Tally) v();
-            else if(d.querySelector('script[src="'+w+'"]')==null){var s=d.createElement("script");s.src=w,s.onload=v,s.onerror=v,d.body.appendChild(s);}
-          </script>
+          <iframe src="https://tally.so/embed/3Nv510?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="276" frameborder="0" marginheight="0" marginwidth="0" title="Wild Tender Hearts "></iframe>
         </section>
  </div>
 </body>


### PR DESCRIPTION
## Summary
- remove external Tally embed script that relied on `eval`
- load form iframe directly

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f5abab308832e8d7cc15c536b8074