### PR TITLE
Move language dropdown to left and raise z-index

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,9 +91,10 @@
     }
     .dropdown {
       position: absolute;
-      right: 1rem;
+      left: 1rem;
       top: 50%;
       transform: translateY(-50%);
+      z-index: 1100;
     }
     .dropbtn {
       background-color: var(--primary-color);
@@ -108,6 +109,7 @@
       background-color: var(--primary-color);
       min-width: 120px;
       box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+      z-index: 1100;
     }
     .dropdown-content a {
       color: #fff;


### PR DESCRIPTION
## Summary
- keep the language dropdown on the left side of the header
- ensure its popup appears above the navigation bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68502aafe104832e9127d2f4eb00e87b